### PR TITLE
Added support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+# command to install dependencies
+install: 
+    - "pip install . --use-mirrors"
+    - "pip install pytest"
+    - "pip install flexmock"
+# command to run tests
+script: py.test


### PR DESCRIPTION
I was adding Travis support for another client and thought it might be useful for you too. It automatically runs all your tests on various versions of Python each time you commit to Github (you need to log into https://travis-ci.org with your github account to add the service hook).
